### PR TITLE
Windows port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 build/
+
+.vs/
+
+premake5.exe

--- a/ktech/engine/input/input.cpp
+++ b/ktech/engine/input/input.cpp
@@ -201,7 +201,7 @@ void KTech::Input::Get()
 	for (size_t i = 0; buf[i]; i++)
 		input += buf[i];
 #else
-	read(0, buf, MAX_INPUT_LENGTH);
+	read(0, buf, sizeof(buf) / sizeof(BufChar));
 	input.assign(buf);
 #endif
 }

--- a/ktech/engine/input/input.hpp
+++ b/ktech/engine/input/input.hpp
@@ -23,6 +23,7 @@
 #define KTECH_DEFINITION
 #include "../../ktech.hpp"
 #undef KTECH_DEFINITION
+#include "../../utility/keys.hpp"
 
 #include <functional>
 #include <string>
@@ -33,7 +34,6 @@
 #else
 #include <termio.h>
 #endif
-
 #include <thread>
 
 class KTech::Input
@@ -81,8 +81,8 @@ private:
 	std::vector<RangedHandler*> m_rangedHandlers;
 	std::vector<CallbacksGroup*> m_groups;
 	bool changedThisTick = false;
-
-	char* Get() const;
+	
+	void Get();
 
 	void Loop();
 

--- a/ktech/engine/input/input.hpp
+++ b/ktech/engine/input/input.hpp
@@ -26,7 +26,14 @@
 
 #include <functional>
 #include <string>
+
+#ifdef _WIN32
+#include <Windows.h>
+#undef RGB
+#else
 #include <termio.h>
+#endif
+
 #include <thread>
 
 class KTech::Input
@@ -63,14 +70,19 @@ public:
 private:
 	Engine* const engine;
 
+#ifdef _WIN32
+	HANDLE m_stdinHandle;
+	DWORD m_oldMode;
+#else
 	termios m_oldTerminalAttributes;
+#endif
 	std::thread m_inputLoop;
 	std::vector<BasicHandler*> m_basicHandlers;
 	std::vector<RangedHandler*> m_rangedHandlers;
 	std::vector<CallbacksGroup*> m_groups;
 	bool changedThisTick = false;
 
-	static char* Get();
+	char* Get() const;
 
 	void Loop();
 

--- a/ktech/engine/output.hpp
+++ b/ktech/engine/output.hpp
@@ -24,9 +24,15 @@
 #include "../ktech.hpp"
 #undef KTECH_DEFINITION
 #include "../basic/point.hpp"
+#include "../basic/upoint.hpp"
 
 #include <string>
+#ifdef _WIN32
+#include <Windows.h>
+#undef RGB
+#else
 #include <termio.h>
+#endif
 #include <vector>
 
 class KTech::Output
@@ -35,7 +41,7 @@ public:
 	const UPoint resolution;
 	std::vector<std::string> outputAfterQuit;
 
-	Output(Engine* const engine, KTech::UPoint imageResolution);
+	Output(Engine* const engine, UPoint imageResolution);
 	~Output();
 
 	static void Log(const std::string& text, RGB color);
@@ -55,7 +61,17 @@ public:
 private:
 	Engine* const engine;
 
+#if _WIN32
+	HANDLE m_stdoutHandle;
+	DWORD m_oldMode;
+	CONSOLE_SCREEN_BUFFER_INFO m_csbi;
+	struct winsize {
+		size_t ws_row;
+		size_t ws_col;
+	} m_terminalSize;
+#else
 	winsize m_terminalSize;
+#endif
 	std::vector<Cell> m_image;
 	std::string m_stringImage;
 };

--- a/ktech/ktech.hpp
+++ b/ktech/ktech.hpp
@@ -64,7 +64,7 @@ namespace KTech
 	template<class T>
 	struct ID;
 	template<class T>
-	inline constexpr ID<T> nullID = ID<T>(0, 0);
+	constexpr ID<T> nullID = ID<T>(0, 0);
 	template<typename T>
 	struct Container;
 	namespace RGBColors {}

--- a/ktech/world/animation.hpp
+++ b/ktech/world/animation.hpp
@@ -62,10 +62,7 @@ public:
 
 		// Delay
 		inline Instruction(Type type, size_t time, Time::Measurement timeMeasurement)
-			: type(type), intData(time), timeMeasurement(timeMeasurement) 
-		{
-
-		}
+			: type(type), intData(time), timeMeasurement(timeMeasurement) {}
 	};
 
 	Engine& engine;

--- a/premake5.lua
+++ b/premake5.lua
@@ -2,6 +2,7 @@
 workspace "KTech"
 	configurations { "Debug", "Release" }
 	location "build"
+	cppdialect "C++17"
 
 -- Include the KTech library
 include "ktech"


### PR DESCRIPTION
The Windows port affects the `Input` and `Output` engine components. These two engine components are the only areas of KTech that include libraries other than the C++ standard libraries.

On GNU/Linux `termios.h` and `unistd.h` are used (which I think both are part of the POSIX standard), while on Windows `Windows.h` is used (which I believe to be somewhat of a silly API, although reading its [Console Documentation](https://learn.microsoft.com/en-us/windows/console/) for sure was a lot nicer than the reading I remember of the GNU/Liunx stuff).

Note: `Animation` is unaffected but `animation.cpp` is included in one of the commits because I've made a small formatting fix. It doesn't matter to the subject of the pull request, yet on the other hand it definitely doesn't justify a GitHub Issue in order to remember doing it later.