### PR TITLE
Call all input callbacks in `Input::CallCallbacks()` while memorizing orders of received inputs

### DIFF
--- a/documentation/faq.md
+++ b/documentation/faq.md
@@ -112,7 +112,7 @@ I chose to register pointers rather than store instances, and `KTech::CachingReg
 
 If the passed `ID` is a non-const reference, `CachingRegistry` will also update its cached index before returning the world structure pointer, expediting future usages of that `ID`. This is why giving `CachingRegistry` non-const `ID` references is preferable, as it should make your game faster if it commonly removes world structures from the register (since removing world structures registered at lower indices is the only valid way a cached index could become stale).
 
-Additionally, considering KTech is designed to work single threaded (with the exception of the input thread), keeping a direct pointer to a world structure retrieved from `CachingRegistry` for the duration of a singular function, after validating it (using `CachingRegistry::Exists()` or checking that the returned pointer is not `nullptr`), is valid practice, as nothing external can erase the pointed world structure from memory, and the input thread ought not remove world structures.
+Additionally, considering KTech is designed to work single threaded, keeping a direct pointer to a world structure retrieved from `CachingRegistry` for the duration of a singular function, after validating it (using `CachingRegistry::Exists()` or checking that the returned pointer is not `nullptr`), is valid practice, as nothing external should erase the pointed world structure from memory in the meantime.
 
 ## KTech's history with the Windows Console and the POSIX terminal
 

--- a/documentation/tutorial/1-introduction.cpp
+++ b/documentation/tutorial/1-introduction.cpp
@@ -87,7 +87,7 @@ int main()
 
 	while (engine.running)
 	{
-		engine.input.CallHandlers();
+		engine.input.CallCallbacks();
 		engine.time.CallInvocations();
 		engine.memory.CallOnTicks();
 

--- a/examples/quickstart/game.cpp
+++ b/examples/quickstart/game.cpp
@@ -51,15 +51,10 @@ struct Character : KTech::Object
 				&Character::Move, // Pointer to the callback function, `Object::Move()`, which requests `Collision` to move this object.
 				this, // Bind this object to the function.
 				KTech::Point(0, 1) // `Move()` has one `Point` parameter which represents where to attempt moving relatively (direction), so bind +1 on the Y axis (which means down) to it.
-			),
-			true // When the key is pressed the function will be called with the next tick if true, or immediately (unsynced and completely outside the game loop's thread) if false. The former works better with physics-related matters (1), while the latter is preferable for UI (2).
-			// Detailed explanations:
-			// 1 - Synchronizing movements triggered by input with changes in physical states (e.g., `Object::Move()` registered to the space key with a ground check executed on-tick to allow further jumping) is helpful to avoid unexpected behavior. On-tick input callback functions are normally called by `Input::CallHandlers()` which may be placed within the game loop, thus they safely finish before any on-tick operations start. 
-			// 2 - KTech does not remember the order of key presses, but rather calls synchronized callback function in the order their corresponding keys were initially registered. Meaning, if the player types into a text field at a keys-per-second rate higher than the game loop's ticks-per-second rate and the input callbacks are called on-tick, the order of input reaching the text field will likely not match the original order of keys pressed by the player.
-		);
-		engine.input.RegisterCallback(KTech::Keys::up, std::bind(&Character::Move, this, KTech::Point(0, -1)), true); // Move up.
-		engine.input.RegisterCallback(KTech::Keys::right, std::bind(&Character::Move, this, KTech::Point(1, 0)), true); // Move right.
-		engine.input.RegisterCallback(KTech::Keys::left, std::bind(&Character::Move, this, KTech::Point(-1, 0)), true); // Move left.
+			));
+		engine.input.RegisterCallback(KTech::Keys::up, std::bind(&Character::Move, this, KTech::Point(0, -1))); // Move up.
+		engine.input.RegisterCallback(KTech::Keys::right, std::bind(&Character::Move, this, KTech::Point(1, 0))); // Move right.
+		engine.input.RegisterCallback(KTech::Keys::left, std::bind(&Character::Move, this, KTech::Point(-1, 0))); // Move left.
 	
 		// Challenge: currently there is nothing for the character instance to be pushed by (which is allowed by collider type we set a moment ago). So, copy this class, change its keybindings and create an instance of it along with the original character (but pass it a different initial position). Now you have two characters controlled by different sets of keys; try making them push each other. 
 	}
@@ -152,7 +147,7 @@ int main()
 	while (engine.running)
 	{
 		// Call...
-		engine.input.CallHandlers(); // ...synchronized input callbacks (as were registered by `character`).
+		engine.input.CallCallbacks(); // ...synchronized input callbacks (as were registered by `character`).
 		engine.time.CallInvocations(); // ...timed invocations (though none were made here).
 		engine.memory.CallOnTicks(); // ...on-tick functions (also left unutilized in this example).
 

--- a/examples/simpleplatform/game.cpp
+++ b/examples/simpleplatform/game.cpp
@@ -140,21 +140,21 @@ struct Character : Object
 		m_colliders[1].Simple(KTech::UPoint(5, 5), 3, KTech::Point(-1, -1));
 
 		KTech::Output::Log("<Character::Character()> Registering callbacks", RGBColors::red);
-		engine.input.RegisterCallback("w", std::bind(&Character::Jump, this), true);
-		engine.input.RegisterCallback("W", std::bind(&Character::Jump, this), true);
-		engine.input.RegisterCallback(" ", std::bind(&Character::Jump, this), true);
-		engine.input.RegisterCallback(KTech::Keys::up, std::bind(&Character::Jump, this), true);
+		engine.input.RegisterCallback("w", std::bind(&Character::Jump, this));
+		engine.input.RegisterCallback("W", std::bind(&Character::Jump, this));
+		engine.input.RegisterCallback(" ", std::bind(&Character::Jump, this));
+		engine.input.RegisterCallback(KTech::Keys::up, std::bind(&Character::Jump, this));
 
-		engine.input.RegisterCallback("d", std::bind(&Character::Move, this, Point(1, 0)), true);
-		engine.input.RegisterCallback("D", std::bind(&Character::Move, this, Point(1, 0)), true);
-		engine.input.RegisterCallback(KTech::Keys::right, std::bind(&Character::Move, this, Point(1, 0)), true);
+		engine.input.RegisterCallback("d", std::bind(&Character::Move, this, Point(1, 0)));
+		engine.input.RegisterCallback("D", std::bind(&Character::Move, this, Point(1, 0)));
+		engine.input.RegisterCallback(KTech::Keys::right, std::bind(&Character::Move, this, Point(1, 0)));
 
-		engine.input.RegisterCallback("a", std::bind(&Character::Move, this, Point(-1, 0)), true);
-		engine.input.RegisterCallback("A", std::bind(&Character::Move, this, Point(-1, 0)), true);
-		engine.input.RegisterCallback(KTech::Keys::left, std::bind(&Character::Move, this, Point(-1, 0)), true);
+		engine.input.RegisterCallback("a", std::bind(&Character::Move, this, Point(-1, 0)));
+		engine.input.RegisterCallback("A", std::bind(&Character::Move, this, Point(-1, 0)));
+		engine.input.RegisterCallback(KTech::Keys::left, std::bind(&Character::Move, this, Point(-1, 0)));
 
-		engine.input.RegisterCallback("f", std::bind(&Character::PushBoxToDifferentLayer, this), true);
-		engine.input.RegisterCallback("F", std::bind(&Character::PushBoxToDifferentLayer, this), true);
+		engine.input.RegisterCallback("f", std::bind(&Character::PushBoxToDifferentLayer, this));
+		engine.input.RegisterCallback("F", std::bind(&Character::PushBoxToDifferentLayer, this));
 
 		KTech::Output::Log("<Character::Character()> Entering layer", RGBColors::red);
 		EnterLayer(layer);
@@ -351,7 +351,7 @@ int main()
 	KTech::Output::Log("<main()> Entering game loop", RGBColors::blue);
 	while (engine.running)
 	{
-		engine.input.CallHandlers();
+		engine.input.CallCallbacks();
 		engine.time.CallInvocations();
 		engine.memory.CallOnTicks();
 

--- a/examples/widgetstest/game.cpp
+++ b/examples/widgetstest/game.cpp
@@ -186,7 +186,7 @@ int main()
 	while (engine.running)
 	{
 		// Calls
-		engine.input.CallHandlers();
+		engine.input.CallCallbacks();
 		engine.time.CallInvocations();
 		engine.memory.CallOnTicks();
 

--- a/ktech/engine/input/callback.cpp
+++ b/ktech/engine/input/callback.cpp
@@ -1,0 +1,27 @@
+/*
+	KTech, Kaup's C++ 2D terminal game engine library.
+	Copyright (C) 2023-2024 Ethan Kaufman (AKA Kaup)
+
+	This file is part of KTech.
+
+	KTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	any later version.
+
+	KTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with KTech. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "callback.hpp"
+#include "handler.hpp"
+
+KTech::Input::Callback::~Callback()
+{
+	parentHandler->RemoveCallback(this);
+}

--- a/ktech/engine/input/callback.hpp
+++ b/ktech/engine/input/callback.hpp
@@ -18,16 +18,18 @@
 	along with KTech. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "callbacks_handlers.hpp"
+#pragma once
 
-KTech::Input::Callback::~Callback()
-{
-	parentHandler->RemoveCallback(this);
-}
+#include "input.hpp"
 
-void KTech::Input::Handler::RemoveCallback(Callback* p_callback)
+struct KTech::Input::Callback
 {
-	for (size_t i = 0; i < m_callbacks.size(); i++)
-		if (m_callbacks[i] == p_callback)
-			m_callbacks.erase(m_callbacks.begin() + i);
-}
+	bool enabled = true;
+	const std::function<bool()> ptr;
+	Handler* const parentHandler;
+
+	inline Callback(const std::function<bool()>& callback, Handler* parentHandler)
+		: ptr(callback), parentHandler(parentHandler) {}
+	
+	~Callback();
+};

--- a/ktech/engine/input/callbacks_handlers.cpp
+++ b/ktech/engine/input/callbacks_handlers.cpp
@@ -20,24 +20,12 @@
 
 #include "callbacks_handlers.hpp"
 
-KTech::Input::BasicCallback::~BasicCallback()
+KTech::Input::Callback::~Callback()
 {
 	parentHandler->RemoveCallback(this);
 }
 
-KTech::Input::RangedCallback::~RangedCallback()
-{
-	parentHandler->RemoveCallback(this);
-}
-
-void KTech::Input::BasicHandler::RemoveCallback(BasicCallback* p_callback)
-{
-	for (size_t i = 0; i < m_callbacks.size(); i++)
-		if (m_callbacks[i] == p_callback)
-			m_callbacks.erase(m_callbacks.begin() + i);
-}
-
-void KTech::Input::RangedHandler::RemoveCallback(RangedCallback* p_callback)
+void KTech::Input::Handler::RemoveCallback(Callback* p_callback)
 {
 	for (size_t i = 0; i < m_callbacks.size(); i++)
 		if (m_callbacks[i] == p_callback)

--- a/ktech/engine/input/callbacks_handlers.hpp
+++ b/ktech/engine/input/callbacks_handlers.hpp
@@ -22,50 +22,36 @@
 
 #include "input.hpp"
 
-struct KTech::Input::BasicCallback
+struct KTech::Input::Callback
 {
 	bool enabled = true;
-	bool onTick;
-	std::function<bool()> ptr;
-	BasicHandler* parentHandler;
-	
-	inline BasicCallback(const std::function<bool()>& callback, BasicHandler* parentHandler, bool onTick)
-		: ptr(callback), parentHandler(parentHandler), onTick(onTick) {}
-	
-	~BasicCallback();
-};
+	const std::function<bool()> ptr;
+	Handler* const parentHandler;
 
-struct KTech::Input::RangedCallback
-{
-	bool enabled = true;
-	std::function<bool()> ptr;
-	RangedHandler* parentHandler;
-
-	inline RangedCallback(const std::function<bool()>& callback, RangedHandler* parentHandler)
+	inline Callback(const std::function<bool()>& callback, Handler* parentHandler)
 		: ptr(callback), parentHandler(parentHandler) {}
 	
-	~RangedCallback();
+	~Callback();
 };
 
-struct KTech::Input::BasicHandler
+struct KTech::Input::Handler
 {
+	enum class Type : uint8_t
+	{
+		String,
+		Range
+	};
+
+	const Type m_type;
+	const char m_key1 = '\0', m_key2 = '\0';
 	const std::string m_input;
-	std::vector<BasicCallback*> m_callbacks; // Callbacks are stored as pointers because the vector changes its size, and CallbackGroups need a consistent pointer to the their callbacks.
-	uint8_t m_timesPressed = 0;
-	
-	inline BasicHandler(const std::string& input)
-		: m_input(input) {};
-	
-	void RemoveCallback(BasicCallback*);
-};
+	std::vector<Callback*> m_callbacks;
 
-struct KTech::Input::RangedHandler
-{
-	const char m_key1, m_key2;
-	std::vector<RangedCallback*> m_callbacks; // Callbacks are stored as pointers because the vector changes its size, and CallbackGroups need a consistent pointer to the their callbacks.
-	
-	inline RangedHandler(char key1, char key2)
-		: m_key1(key1), m_key2(key2) {};
+	inline Handler(const::std::string& input)
+		: m_input(input), m_type(Type::String) {}
 
-	void RemoveCallback(RangedCallback*);
+	inline Handler(char key1, char key2)
+		: m_key1(key1), m_key2(key2), m_type(Type::Range) {}
+
+	void RemoveCallback(Callback* callback);
 };

--- a/ktech/engine/input/callbacksgroup.cpp
+++ b/ktech/engine/input/callbacksgroup.cpp
@@ -22,16 +22,10 @@
 
 #include "callbacks_handlers.hpp"
 
-void KTech::Input::CallbacksGroup::AddCallback(BasicCallback* callback)
+void KTech::Input::CallbacksGroup::AddCallback(Callback* p_callback)
 {
-	m_basicCallbacks.push_back(callback);
-	callback->enabled = false;
-}
-
-void KTech::Input::CallbacksGroup::AddCallback(RangedCallback* callback)
-{
-	m_rangedCallbacks.push_back(callback);
-	callback->enabled = false;
+	m_callbacks.push_back(p_callback);
+	p_callback->enabled = false;
 }
 
 void KTech::Input::CallbacksGroup::Enable()
@@ -49,10 +43,8 @@ void KTech::Input::CallbacksGroup::Disable()
 void KTech::Input::CallbacksGroup::DeleteCallbacks()
 {
 	// Disable as soon as possible the callbacks (since the actual callbacks are probably deleted right after)
-	for (BasicCallback* basicCallback : m_basicCallbacks)
-		basicCallback->enabled = false;
-	for (RangedCallback* rangedCallback : m_rangedCallbacks)
-		rangedCallback->enabled = false;
+	for (Callback* callback : m_callbacks)
+		callback->enabled = false;
 	// Then request to delete the callbacks
 	// (removeDisabled will set the group to be disabled later, removeEnabled will set to enabled)
 	m_status = (m_status == Status::disabled ? Status::removeDisabled : Status::removeEnabled);
@@ -61,60 +53,43 @@ void KTech::Input::CallbacksGroup::DeleteCallbacks()
 
 void KTech::Input::CallbacksGroup::Update()
 {
-	if (!m_synced)
+	switch (m_status)
 	{
-		switch (m_status)
+		case Status::disabled:
 		{
-			case Status::disabled:
-			{
-				// Disalbe the callbacks
-				for (BasicCallback* basicCallback : m_basicCallbacks)
-					basicCallback->enabled = false;
-				for (RangedCallback* rangedCallback : m_rangedCallbacks)
-					rangedCallback->enabled = false;
-				break;
-			}
-			case Status::enabled:
-			{
-				// Enable the callbacks
-				for (BasicCallback* basicCallback : m_basicCallbacks)
-					basicCallback->enabled = true;
-				for (RangedCallback* rangedCallback : m_rangedCallbacks)
-					rangedCallback->enabled = true;
-				break;
-			}
-			case Status::removeDisabled:
-			{
-				// Delete the callbacks from memory (which will automatically delete the callbacks from
-				// their parent handlers' callback vector)
-				for (BasicCallback*& basicCallback : m_basicCallbacks)
-				{
-					delete basicCallback;
-				}
-				for (RangedCallback*& rangedCallback : m_rangedCallbacks)
-					delete rangedCallback;
-				// Clearthe group's vectors
-				m_basicCallbacks.clear();
-				m_rangedCallbacks.clear();
-				// Disable the group as requested
-				m_status = CallbacksGroup::Status::disabled;
-				break;
-			}
-			case Status::removeEnabled:
-			{
-				// The same as ^ but enable the group afterwards
-				for (BasicCallback* basicCallback : m_basicCallbacks)
-				{
-					delete basicCallback;
-				}
-				for (RangedCallback* rangedCallback : m_rangedCallbacks)
-					delete rangedCallback;
-				m_basicCallbacks.clear();
-				m_rangedCallbacks.clear();
-				m_status = Status::enabled;
-				break;
-			}
+			// Disalbe the callbacks
+			for (Callback* callback : m_callbacks)
+				callback->enabled = false;
+			break;
 		}
-		m_synced = true;
+		case Status::enabled:
+		{
+			// Enable the callbacks
+			for (Callback* callback : m_callbacks)
+				callback->enabled = true;
+			break;
+		}
+		case Status::removeDisabled:
+		{
+			// Delete the callbacks from memory (which will automatically delete the callbacks from
+			// their parent handlers' callback vector)
+			for (Callback*& callback : m_callbacks)
+				delete callback;
+			// Clear the group's vectors
+			m_callbacks.clear();
+			// Disable the group as requested
+			m_status = CallbacksGroup::Status::disabled;
+			break;
+		}
+		case Status::removeEnabled:
+		{
+			// The same as ^ but enable the group afterwards
+			for (Callback* callback : m_callbacks)
+				delete callback;
+			m_callbacks.clear();
+			m_status = Status::enabled;
+			break;
+		}
 	}
+	m_synced = true;
 }

--- a/ktech/engine/input/callbacksgroup.cpp
+++ b/ktech/engine/input/callbacksgroup.cpp
@@ -20,7 +20,7 @@
 
 #include "callbacksgroup.hpp"
 
-#include "callbacks_handlers.hpp"
+#include "callback.hpp"
 
 void KTech::Input::CallbacksGroup::AddCallback(Callback* p_callback)
 {
@@ -57,7 +57,7 @@ void KTech::Input::CallbacksGroup::Update()
 	{
 		case Status::disabled:
 		{
-			// Disalbe the callbacks
+			// Disable the callbacks
 			for (Callback* callback : m_callbacks)
 				callback->enabled = false;
 			break;

--- a/ktech/engine/input/callbacksgroup.hpp
+++ b/ktech/engine/input/callbacksgroup.hpp
@@ -22,9 +22,8 @@
 
 #include "input.hpp"
 
-class KTech::Input::CallbacksGroup
+struct KTech::Input::CallbacksGroup
 {
-public:
 	enum class Status : uint8_t
 	{
 		disabled,
@@ -33,11 +32,14 @@ public:
 		removeEnabled, // Remove and then return status to enabled
 	};
 
+	std::vector<Callback*> m_callbacks;
+	Status m_status;
+	bool m_synced = true;
+
 	CallbacksGroup(bool enabled = true)
 		: m_status(enabled ? Status::enabled : Status::disabled) {}
 		
-	void AddCallback(BasicCallback* basicCallback);
-	void AddCallback(RangedCallback* rangedCallback);
+	void AddCallback(Callback* basicCallback);
 	
 	void DeleteCallbacks();
 	
@@ -45,10 +47,4 @@ public:
 	void Disable();
 
 	void Update();
-
-private:
-	std::vector<BasicCallback*> m_basicCallbacks;
-	std::vector<RangedCallback*> m_rangedCallbacks;
-	Status m_status;
-	bool m_synced = true;
 };

--- a/ktech/engine/input/handler.cpp
+++ b/ktech/engine/input/handler.cpp
@@ -1,0 +1,28 @@
+/*
+	KTech, Kaup's C++ 2D terminal game engine library.
+	Copyright (C) 2023-2024 Ethan Kaufman (AKA Kaup)
+
+	This file is part of KTech.
+
+	KTech is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	any later version.
+
+	KTech is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with KTech. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "handler.hpp"
+
+void KTech::Input::Handler::RemoveCallback(Callback* p_callback)
+{
+	for (size_t i = 0; i < m_callbacks.size(); i++)
+		if (m_callbacks[i] == p_callback)
+			m_callbacks.erase(m_callbacks.begin() + i);
+}

--- a/ktech/engine/input/handler.hpp
+++ b/ktech/engine/input/handler.hpp
@@ -22,18 +22,6 @@
 
 #include "input.hpp"
 
-struct KTech::Input::Callback
-{
-	bool enabled = true;
-	const std::function<bool()> ptr;
-	Handler* const parentHandler;
-
-	inline Callback(const std::function<bool()>& callback, Handler* parentHandler)
-		: ptr(callback), parentHandler(parentHandler) {}
-	
-	~Callback();
-};
-
 struct KTech::Input::Handler
 {
 	enum class Type : uint8_t
@@ -42,16 +30,16 @@ struct KTech::Input::Handler
 		Range
 	};
 
-	const Type m_type;
-	const char m_key1 = '\0', m_key2 = '\0';
-	const std::string m_input;
+	// const Type m_type;
+	const char m_start = '\0', m_end = '\0';
+	const std::string m_string;
 	std::vector<Callback*> m_callbacks;
 
 	inline Handler(const::std::string& input)
-		: m_input(input), m_type(Type::String) {}
+		: m_string(input) {}
 
 	inline Handler(char key1, char key2)
-		: m_key1(key1), m_key2(key2), m_type(Type::Range) {}
+		: m_start(key1), m_end(key2) {}
 
 	void RemoveCallback(Callback* callback);
 };

--- a/ktech/engine/input/input.cpp
+++ b/ktech/engine/input/input.cpp
@@ -166,9 +166,9 @@ void KTech::Input::CallCallbacks()
 			group->Update();
 	
 	// Call callbacks of triggered handlers
-	for (std::string& trigger : m_triggers)
+	for (size_t i; i < m_inputQueue.size(); i++)
 	{
-		input = std::move(trigger);
+		input = std::move(m_inputQueue[i]);
 		if (input.length() == 1) // Can be both string/range handler
 		{
 			for (Handler* stringHandler : m_stringHandlers) // Input matches handler's string
@@ -207,7 +207,7 @@ void KTech::Input::CallCallbacks()
 	}
 
 	// All callbacks of triggered handlers were called; clear trigger history
-	m_triggers.clear();
+	m_inputQueue.clear();
 }
 
 void KTech::Input::Get()
@@ -223,13 +223,13 @@ void KTech::Input::Get()
 	for (size_t i = 0; i < (size_t)nReadCharacters; i++)
 		charBuf[i] = tcharBuf[i];
 	// Move to input history
-	m_triggers.push_back(std::move(charBuf));
+	m_inputQueue.push_back(std::move(charBuf));
 #else
 	// Read
 	std::string buf(7, '\0');
 	buf.resize(read(0, buf.data(), buf.size()));
 	// Move to input history
-	m_triggers.push_back(std::move(buf));
+	m_inputQueue.push_back(std::move(buf));
 #endif
 }
 
@@ -239,7 +239,7 @@ void KTech::Input::Loop()
 	{
 		// Get input
 		Get();
-		if (m_triggers[m_triggers.size() - 1] == quitKey)
+		if (m_inputQueue[m_inputQueue.size() - 1] == quitKey)
 		{
 			// Quit
 			engine->running = false;

--- a/ktech/engine/input/input.cpp
+++ b/ktech/engine/input/input.cpp
@@ -212,19 +212,22 @@ void KTech::Input::CallCallbacks()
 void KTech::Input::Get()
 {
 #ifdef _WIN32
-	// Add space in history
-	m_triggers.push_back(std::move(std::string()));
-	// Write input to history (TCHAR to char conversion)
+	// Read
+	TCHAR tcharBuf[7];
+	memset(tcharBuf, 0, sizeof(tcharBuf));
 	LPDWORD nReadCharacters = 0;
-	TCHAR buf[7];
-	memset(buf, 0, sizeof(buf));
-	ReadConsole(m_stdinHandle, buf.data(), buf.length(), (LPDWORD)(&nReadCharacters), NULL);
-	m_triggers[m_triggers.size() - 1].resize(nReadCharacters);
-	for (size_t i = 0; i < nReadCharacters; i++)
-		m_triggers[m_triggers.size() - 1] += buf[i];
+	ReadConsole(m_stdinHandle, tcharBuf, sizeof(tcharBuf) / sizeof(TCHAR), (LPDWORD)(&nReadCharacters), NULL);
+	// Convert `TCHAR` string to `char` string
+	std::string charBuf((size_t)nReadCharacters, '\0');
+	for (size_t i = 0; i < (size_t)nReadCharacters; i++)
+		charBuf[i] = tcharBuf[i];
+	// Move to input history
+	m_triggers.push_back(std::move(charBuf));
 #else
+	// Read
 	std::string buf(7, '\0');
 	buf.resize(read(0, buf.data(), buf.size()));
+	// Move to input history
 	m_triggers.push_back(std::move(buf));
 #endif
 }

--- a/ktech/engine/input/input.hpp
+++ b/ktech/engine/input/input.hpp
@@ -23,7 +23,6 @@
 #define KTECH_DEFINITION
 #include "../../ktech.hpp"
 #undef KTECH_DEFINITION
-#include "../../utility/keys.hpp"
 
 #include <functional>
 #include <string>
@@ -76,7 +75,8 @@ private:
 
 	bool changedThisTick = false;
 	std::thread m_inputLoop;
-	std::vector<Handler*> m_handlers;
+	std::vector<Handler*> m_stringHandlers; // String and range handlers are split here for the sake of simplicity in `Input::CallCallbacks()` by pruning previously-existing `Handler::m_type`
+	std::vector<Handler*> m_rangeHandlers;
 	std::vector<CallbacksGroup*> m_groups;
 	std::vector<std::string> m_triggers;
 	

--- a/ktech/engine/input/input.hpp
+++ b/ktech/engine/input/input.hpp
@@ -39,22 +39,20 @@
 class KTech::Input
 {
 public:
-	struct BasicCallback;
-	struct BasicHandler;
-	struct RangedCallback;
-	struct RangedHandler;
+	struct Handler;
+	struct Callback;
 	class CallbacksGroup;
 	
 	std::string input;
-	std::string quitKey = "\x03";
+	std::string quitKey{"\x03"};
 
 	// Prepares terminal, creates input loop thread
 	Input(Engine* const engine);
 	// Resets terminal
 	~Input();
 
-	BasicCallback* RegisterCallback(const std::string& stringKey, const std::function<bool()>& callback, bool onTick = false);
-	RangedCallback* RegisterRangedCallback(char key1, char key2, const std::function<bool()>& callback);
+	Callback* RegisterCallback(const std::string& stringKey, const std::function<bool()>& callback);
+	Callback* RegisterRangedCallback(char key1, char key2, const std::function<bool()>& callback);
 	CallbacksGroup* CreateCallbacksGroup(bool enabled = true);
 
 	bool Is(const std::string& stringKey) const;
@@ -64,7 +62,7 @@ public:
 	bool Between(char charKey1, char charKey2) const;
 	uint8_t GetInt() const;
 
- 	void CallHandlers();
+ 	void CallCallbacks();
 
 private:
 	Engine* const engine;
@@ -75,11 +73,12 @@ private:
 #else
 	termios m_oldTerminalAttributes;
 #endif
+
 	bool changedThisTick = false;
 	std::thread m_inputLoop;
-	std::vector<BasicHandler*> m_basicHandlers;
-	std::vector<RangedHandler*> m_rangedHandlers;
+	std::vector<Handler*> m_handlers;
 	std::vector<CallbacksGroup*> m_groups;
+	std::vector<std::string> m_triggers;
 	
 	void Get();
 

--- a/ktech/engine/input/input.hpp
+++ b/ktech/engine/input/input.hpp
@@ -78,7 +78,7 @@ private:
 	std::vector<Handler*> m_stringHandlers; // String and range handlers are split here for the sake of simplicity in `Input::CallCallbacks()` by pruning previously-existing `Handler::m_type`
 	std::vector<Handler*> m_rangeHandlers;
 	std::vector<CallbacksGroup*> m_groups;
-	std::vector<std::string> m_triggers;
+	std::vector<std::string> m_inputQueue;
 	
 	void Get();
 

--- a/ktech/widgets/button.hpp
+++ b/ktech/widgets/button.hpp
@@ -44,7 +44,7 @@ public:
 		// Texture
 		SetText(text, withFrame);
 		// Input handlers
-		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(key, std::bind(&Button::InsideOnPress, this), false));
+		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(key, std::bind(&Button::InsideOnPress, this)));
 	}
 
 	virtual ~Button()

--- a/ktech/widgets/intfield.hpp
+++ b/ktech/widgets/intfield.hpp
@@ -57,8 +57,8 @@ public:
 		SetValue(defaultNum);
 		// Input handlers
 		m_callbacksGroup->AddCallback(engine.input.RegisterRangedCallback('0', '9', std::bind(&IntField::InternalInsert, this)));
-		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::backspace, std::bind(&IntField::InternalInsert, this), false));
-		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::delete_, std::bind(&IntField::InternalInsert, this), false));
+		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::backspace, std::bind(&IntField::InternalInsert, this)));
+		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::delete_, std::bind(&IntField::InternalInsert, this)));
 	}
 
 	void SetText(const std::string& text, bool withFrame)

--- a/ktech/widgets/stringfield.hpp
+++ b/ktech/widgets/stringfield.hpp
@@ -61,8 +61,8 @@ public:
 		// Input handlers
 		for (KeyRange& keyRange : allowedCharacters)
 			m_callbacksGroup->AddCallback(engine.input.RegisterRangedCallback(keyRange.key1, keyRange.key2, std::bind(&StringField::OnInsert, this)));
-		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::delete_, std::bind(&StringField::OnInsert, this), false));
-		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::backspace, std::bind(&StringField::OnInsert, this), false));
+		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::delete_, std::bind(&StringField::OnInsert, this)));
+		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(KTech::Keys::backspace, std::bind(&StringField::OnInsert, this)));
 	}
 
 	void SetText(const std::string& text, bool withFrame)

--- a/ktech/widgets/switch.hpp
+++ b/ktech/widgets/switch.hpp
@@ -49,7 +49,7 @@ public:
 		// Textures
 		SetText(text, withFrame);
 		// Input handlers
-		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(key, std::bind(&Switch::OnPress, this), false));
+		m_callbacksGroup->AddCallback(engine.input.RegisterCallback(key, std::bind(&Switch::OnPress, this)));
 	}
 
 	virtual ~Switch()


### PR DESCRIPTION
This pull request (suggested in issue #113) makes the `Input` engine component accumulate user inputs in `Input::Get()` until `Input::CallCallbacks()` (previously `CallHandlers()`) is called, which distributes inputs while still keeping the order in which they were initially received. In other words, this change embeds the "on-tick" feature into all callbacks (so the `onTick` parameter in `Input::RegisterInputCallback()` was removed).

This update hugely simplifies registering input callbacks, as the user no longer needs to learn about the crucial consideration, between the game loop's thread and `Input`'s thread, that had to come when it was time to register an input callback function. Additionally, as issue #113 details, the previous system could let an unwitting user meet memory related bugs by removing world structures from `CachingRegistry`.

This pull request also refactors the back end of `Input` by merging `BasicCallback` and `RangedCallback` into `Callback`, and `BasicHandler` and `RangedHandler` into `Handler`.

List of changes:

- The input-queuing system described above.
- Renamed `Input::CallHandlers()` to `Input::CallCallbacks()`.
- Merged `Input::RangedCallback()` and `Input::BasicCallback()` into a singular class `Input::Callback()`.
- Merged `Input::RangedHandler()` and `Input::Basichandler()` into a singular class `Input::Handler()`.
- Removed redundant `onTick` parameter from `Input::RegisterCallback()`.
- Split `Callback` and `Handler` definitions to `callback.*` and `handler.*` files respectively.
- Updated `faq.md` "How does `CachingRegistry` work?" entry regarding this update.

This pull request solves #113.