### PR TITLE
Fix various errors on Windows.

### DIFF
--- a/ktech/engine/input/input.cpp
+++ b/ktech/engine/input/input.cpp
@@ -249,11 +249,11 @@ void KTech::Input::Get()
 	// Read
 	TCHAR tcharBuf[7];
 	memset(tcharBuf, 0, sizeof(tcharBuf));
-	LPDWORD nReadCharacters = 0;
-	ReadConsole(m_stdinHandle, tcharBuf, sizeof(tcharBuf) / sizeof(TCHAR), (LPDWORD)(&nReadCharacters), NULL);
+	DWORD nReadCharacters = 0;
+	ReadConsole(m_stdinHandle, tcharBuf, sizeof(tcharBuf) / sizeof(TCHAR), &nReadCharacters, NULL);
 	// Convert `TCHAR` string to `char` string
-	std::string charBuf(static_cast<size_t>(nReadCharacters), '\0');
-	for (size_t i = 0; i < static_cast<size_t>(nReadCharacters); i++)
+	std::string charBuf(nReadCharacters, '\0');
+	for (size_t i = 0; i < nReadCharacters; i++)
 	{
 		charBuf[i] = tcharBuf[i];
 	}

--- a/ktech/engine/output.cpp
+++ b/ktech/engine/output.cpp
@@ -387,7 +387,7 @@ auto KTech::Output::ShouldPrintThisTick() const -> bool
 {
 	winsize tempTerminalSize;
 #ifdef _WIN32
-	GetConsoleScreenBufferInfo(m_stdoutHandle, &m_csbi);
+	GetConsoleScreenBufferInfo(m_stdoutHandle, PCONSOLE_SCREEN_BUFFER_INFO(&m_csbi));
 	tempTerminalSize.ws_col = m_csbi.srWindow.Right - m_csbi.srWindow.Left + 1;
 	tempTerminalSize.ws_row = m_csbi.srWindow.Bottom - m_csbi.srWindow.Top + 1;
 #else

--- a/ktech/engine/output.hpp
+++ b/ktech/engine/output.hpp
@@ -30,7 +30,6 @@
 #include <string>
 #ifdef _WIN32
 #include <Windows.h>
-#undef RGB
 #else
 #include <termio.h>
 #endif

--- a/ktech/engine/time.cpp
+++ b/ktech/engine/time.cpp
@@ -167,14 +167,20 @@ void KTech::Time::CallInvocations()
 */
 void KTech::Time::WaitUntilNextTick()
 {
-	// Calculate `tpsPotential`
+	// Calculate delta of current tick (`deltaTime`)
 	deltaTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - m_currentTickStart).count();
+	// Calculate `tpsPotential`
 	tpsPotential = 1000000.0F / deltaTime;
-	// Sleep according to `tpsLimit`
-	std::this_thread::sleep_for(std::chrono::microseconds(1000000 / tpsLimit - deltaTime));
+	// Calculate sleep duration according to `tpsLimit`
+	auto sleepDuration = std::chrono::microseconds(1000000 / tpsLimit) - std::chrono::microseconds(deltaTime);
+	// Sleep only if needed
+	if (sleepDuration.count() > 0) {
+		std::this_thread::sleep_for(sleepDuration);
+	}
 	// Calculate (actual) `tps`
 	deltaTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - m_currentTickStart).count();
 	tps = 1000000.0F / deltaTime;
-	m_currentTickStart = std::chrono::high_resolution_clock::now();
+	// Set `m_currentTickStart` to now
 	ticksCounter++;
+	m_currentTickStart = std::chrono::high_resolution_clock::now();
 }

--- a/ktech/engine/time.hpp
+++ b/ktech/engine/time.hpp
@@ -57,7 +57,7 @@ public:
 	size_t tpsLimit; //!< Max ticks allowed to occur in a second. You set this value in `Engine::Engine()`, and you can change it whenever you want.
 	float tps; //!< Actual ticks per second. Corresponds to `Time::deltaTime`.
 	float tpsPotential; //!< Ticks per second if it wasn't limited by `Time::tpsLimit`.
-	size_t deltaTime; //!< Duration of the last tick, in microseconds.
+	long deltaTime; //!< Duration of the last tick, in microseconds.
 	size_t ticksCounter = 0; //!< Total ticks since game started.
 
 	auto Invoke(const std::function<bool()>& callback, size_t time, Measurement timeMeasurement) -> Invocation*;

--- a/ktech/ktech.hpp
+++ b/ktech/ktech.hpp
@@ -28,8 +28,6 @@
 
 #pragma once
 
-#include <cstdint>
-
 namespace KTech
 {
 	// Basic structures.
@@ -70,6 +68,13 @@ namespace KTech
 	namespace RGBAColors {}
 	namespace Keys {}
 }
+
+#include <cstdint>
+#ifdef _WIN32
+#include <Windows.h>
+#undef RGB
+#undef max
+#endif
 
 #ifndef KTECH_DEFINITION // See `documentation/faq.md#`
 #include "basic/point.hpp"


### PR DESCRIPTION
Fix `Time::WaitUntilNextTick()` potentially calling `std::this_thread::sleep_for()` on a negative duration (which nearly always happens after the first tick), which completely breaks Windows port.